### PR TITLE
Fix errors when using cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,8 @@ runs:
         brew update --preinstall
         brew_repository="$(brew --repository)"
         mkdir -p .github
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/lima.rb" > .github/brew-lima
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/colima.rb" > .github/brew-colima
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/lima.rb" > .github/brew-lima
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/docker.rb" > .github/brew-docker
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/docker-compose.rb" > .github/brew-docker-compose
       shell: bash
@@ -37,8 +37,8 @@ runs:
       uses: actions/cache@v3.3.1
       with:
         path: |
-          ${{ env.BREW_CELLAR }}/lima
           ${{ env.BREW_CELLAR }}/colima
+          ${{ env.BREW_CELLAR }}/lima
           ${{ env.BREW_CELLAR }}/docker
           ${{ env.BREW_CELLAR }}/docker-compose
         key: brew-${{ hashFiles('.github/brew-*') }}

--- a/action.yml
+++ b/action.yml
@@ -43,10 +43,13 @@ runs:
           ${{ env.BREW_CELLAR }}/docker-compose
         key: brew-${{ hashFiles('.github/brew-*') }}
         restore-keys: brew-${{ hashFiles('.github/brew-*') }}
+    - name: Install packages that depends on Colima restored from cache
+      if: ${{ steps.homebrew-cache.outputs.cache-hit == 'true' }}
+      run: brew install --only-dependencies colima
+      shell: bash
     - name: Relink Docker client, Docker Compose, and Colima
       if: ${{ steps.homebrew-cache.outputs.cache-hit == 'true' }}
       run: |
-        brew install qemu
         brew unlink docker docker-compose colima lima
         brew link docker docker-compose colima lima
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
       if: ${{ steps.homebrew-cache.outputs.cache-hit == 'true' }}
       run: |
         brew unlink docker docker-compose colima lima qemu xz vde snappy ncurses libssh libslirp gnutls openssl@3 capstone
-        brew link docker docker-compose colima lima qemu xz vde snappy ncurses libssh libslirp gnutls openssl@3 capstone
+        brew link --overwrite docker docker-compose colima lima qemu xz vde snappy ncurses libssh libslirp gnutls openssl@3 capstone
       shell: bash
     - name: Install Docker client, Docker Compose, and Colima.
       if: ${{ steps.homebrew-cache.outputs.cache-hit != 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -24,16 +24,6 @@ runs:
         brew update --preinstall
         brew_repository="$(brew --repository)"
         mkdir -p .github
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/capstone.rb" > .github/brew-capstone
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/openssl@3.rb" > .github/brew-openssl@3
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/gnutls.rb" > .github/brew-gnutls
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/libslirp.rb" > .github/brew-libslirp
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/libssh.rb" > .github/brew-libssh
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/ncurses.rb" > .github/brew-ncurses
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/snappy.rb" > .github/brew-snappy
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/vde.rb" > .github/brew-vde
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/xz.rb" > .github/brew-xz
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/qemu.rb" > .github/brew-qemu
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/lima.rb" > .github/brew-lima
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/colima.rb" > .github/brew-colima
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/docker.rb" > .github/brew-docker
@@ -47,16 +37,6 @@ runs:
       uses: actions/cache@v3.3.1
       with:
         path: |
-          ${{ env.BREW_CELLAR }}/capstone
-          ${{ env.BREW_CELLAR }}/openssl@3
-          ${{ env.BREW_CELLAR }}/gnutls
-          ${{ env.BREW_CELLAR }}/libslirp
-          ${{ env.BREW_CELLAR }}/libssh
-          ${{ env.BREW_CELLAR }}/ncurses
-          ${{ env.BREW_CELLAR }}/snappy
-          ${{ env.BREW_CELLAR }}/vde
-          ${{ env.BREW_CELLAR }}/xz
-          ${{ env.BREW_CELLAR }}/qemu
           ${{ env.BREW_CELLAR }}/lima
           ${{ env.BREW_CELLAR }}/colima
           ${{ env.BREW_CELLAR }}/docker
@@ -66,8 +46,9 @@ runs:
     - name: Relink Docker client, Docker Compose, and Colima
       if: ${{ steps.homebrew-cache.outputs.cache-hit == 'true' }}
       run: |
-        brew unlink docker docker-compose colima lima qemu xz vde snappy ncurses libssh libslirp gnutls openssl@3 capstone
-        brew link --overwrite docker docker-compose colima lima qemu xz vde snappy ncurses libssh libslirp gnutls openssl@3 capstone
+        brew install qemu
+        brew unlink docker docker-compose colima lima
+        brew link docker docker-compose colima lima
       shell: bash
     - name: Install Docker client, Docker Compose, and Colima.
       if: ${{ steps.homebrew-cache.outputs.cache-hit != 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,9 @@ runs:
         brew update --preinstall
         brew_repository="$(brew --repository)"
         mkdir -p .github
-        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/colima.rb" > .github/brew-colima
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/qemu.rb" > .github/brew-qemu
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/lima.rb" > .github/brew-lima
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/colima.rb" > .github/brew-colima
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/docker.rb" > .github/brew-docker
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/docker-compose.rb" > .github/brew-docker-compose
       shell: bash
@@ -37,8 +38,9 @@ runs:
       uses: actions/cache@v3.3.1
       with:
         path: |
-          ${{ env.BREW_CELLAR }}/colima
+          ${{ env.BREW_CELLAR }}/qemu
           ${{ env.BREW_CELLAR }}/lima
+          ${{ env.BREW_CELLAR }}/colima
           ${{ env.BREW_CELLAR }}/docker
           ${{ env.BREW_CELLAR }}/docker-compose
         key: brew-${{ hashFiles('.github/brew-*') }}
@@ -46,8 +48,8 @@ runs:
     - name: Relink Docker client, Docker Compose, and Colima
       if: ${{ steps.homebrew-cache.outputs.cache-hit == 'true' }}
       run: |
-        brew unlink docker docker-compose colima lima
-        brew link docker docker-compose colima lima
+        brew unlink docker docker-compose colima lima qemu
+        brew link docker docker-compose colima lima qemu
       shell: bash
     - name: Install Docker client, Docker Compose, and Colima.
       if: ${{ steps.homebrew-cache.outputs.cache-hit != 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,15 @@ runs:
         brew update --preinstall
         brew_repository="$(brew --repository)"
         mkdir -p .github
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/capstone.rb" > .github/brew-capstone
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/openssl@3.rb" > .github/brew-openssl@3
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/gnutls.rb" > .github/brew-gnutls
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/libslirp.rb" > .github/brew-libslirp
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/libssh.rb" > .github/brew-libssh
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/ncurses.rb" > .github/brew-ncurses
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/snappy.rb" > .github/brew-snappy
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/vde.rb" > .github/brew-vde
+        cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/xz.rb" > .github/brew-xz
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/qemu.rb" > .github/brew-qemu
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/lima.rb" > .github/brew-lima
         cat "$brew_repository/Library/Taps/homebrew/homebrew-core/Formula/colima.rb" > .github/brew-colima
@@ -38,6 +47,15 @@ runs:
       uses: actions/cache@v3.3.1
       with:
         path: |
+          ${{ env.BREW_CELLAR }}/capstone
+          ${{ env.BREW_CELLAR }}/openssl@3
+          ${{ env.BREW_CELLAR }}/gnutls
+          ${{ env.BREW_CELLAR }}/libslirp
+          ${{ env.BREW_CELLAR }}/libssh
+          ${{ env.BREW_CELLAR }}/ncurses
+          ${{ env.BREW_CELLAR }}/snappy
+          ${{ env.BREW_CELLAR }}/vde
+          ${{ env.BREW_CELLAR }}/xz
           ${{ env.BREW_CELLAR }}/qemu
           ${{ env.BREW_CELLAR }}/lima
           ${{ env.BREW_CELLAR }}/colima
@@ -48,8 +66,8 @@ runs:
     - name: Relink Docker client, Docker Compose, and Colima
       if: ${{ steps.homebrew-cache.outputs.cache-hit == 'true' }}
       run: |
-        brew unlink docker docker-compose colima lima qemu
-        brew link docker docker-compose colima lima qemu
+        brew unlink docker docker-compose colima lima qemu xz vde snappy ncurses libssh libslirp gnutls openssl@3 capstone
+        brew link docker docker-compose colima lima qemu xz vde snappy ncurses libssh libslirp gnutls openssl@3 capstone
       shell: bash
     - name: Install Docker client, Docker Compose, and Colima.
       if: ${{ steps.homebrew-cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
The lima package depends on the qemu package.
``` sh
% brew info lima
==> lima: stable 0.17.0 (bottled), HEAD
Linux virtual machines
https://github.com/lima-vm/lima
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/lima.rb
License: Apache-2.0
==> Dependencies
Build: go ✘
Required: qemu ✘

```

So I added the qemu installation by brew before restoring cached packages.

I tried to cache the quemu and packages that depend on it. But the qumu could not be recovered.

Although Not all brew cellars are cached, it would be worthwhile for docker to be cached.

<img width="993" alt="스크린샷 2023-08-10 오후 9 22 46" src="https://github.com/douglascamata/setup-docker-macos-action/assets/3667927/fac08c61-67d6-4eb3-a735-47b0a68a6281">
