### PR TITLE
Improve resliency of action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - "main"
   pull_request:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Changed
+
+- Improve reliability of action ([#19](https://github.com/douglascamata/setup-docker-macos-action/pull/19))
+  - Colima and Lima binaries are now downloaded straight from their Github Release pages
+  - By default, use `brew` only to install the Docker client and Docker Compose.
+  - QEMU is now installed (using `brew`) only if it's not already present.
+  - QEMU is upgraded (using `brew`) only if the input `upgrade-qemu` is set to `"true"`.
+
 ## [v1-alpha.9] - 2023-08-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,12 +9,22 @@ This action installs Docker on a macOS runner through [Colima], [Lima-VM], and [
 I intend this action to be kept as simple as possible:
 
 - No other OS will be supported.
-- No other installation method for Colima will be supported (means you will always get what Homebrew gives you).
+- Binaries will be downloaded directly from the source when possible.
 
 ## Features
 
 - Safety check to ensure the action is running in macOS.
-- Caches big Homebrew packages to save some CI minutes.
+- As simple and lightweight (downloads binaries directly when possible).
+
+## Inputs
+
+## `inputs.upgrade-qemu` (defaults to `"false"`)
+
+The action, by default, will not try to upgrade QEMU if it's already installed.
+The reason is that installing QEMU takes a considerable amount of time.
+
+If this is set to `"true"`, the action will attempt an upgrade of QEMU to the
+latest version available in Homebrew.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
       shell: bash
     - name: Upgrade QEMU
-      if: inputs.upgrade-qemu == "true"
+      if: ${{ inputs.upgrade-qemu == "true" }}
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"
         HOMEBREW_NO_INSTALL_UPGRADE: "1"

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
 
         # download binary
         COLIMA_VERSION=$(curl -fsSL https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
-        curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA}/colima-$(uname)-$(uname -m)
+        curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA_VERSION}/colima-$(uname)-$(uname -m)
 
         # install in $PATH
         install colima-$(uname)-$(uname -m) /usr/local/bin/colima

--- a/action.yml
+++ b/action.yml
@@ -22,52 +22,27 @@ runs:
     - name: Update Homebrew
       run: |
         brew update --preinstall
-        brew_repository="$(brew --repository)"
-        mkdir -p .github
-        cd .github
-        cat "$(brew edit --print-path --formula colima)" > brew-colima
-        cat "$(brew edit --print-path --formula lima)" > brew-lima
-        cat "$(brew edit --print-path --formula docker )" > brew-docker
-        cat "$(brew edit --print-path --formula docker-compose)" > brew-docker-compose
       shell: bash
-    - name: Pre-cache
-      run: echo "BREW_CELLAR=$(brew --cellar)" >> $GITHUB_ENV
-      shell: bash
-    - name: Configure Homebrew cache
-      id: homebrew-cache
-      uses: actions/cache@v3.3.1
-      with:
-        path: |
-          ${{ env.BREW_CELLAR }}/colima
-          ${{ env.BREW_CELLAR }}/lima
-          ${{ env.BREW_CELLAR }}/docker
-          ${{ env.BREW_CELLAR }}/docker-compose
-        key: brew-${{ hashFiles('.github/brew-*') }}
-        restore-keys: brew-${{ hashFiles('.github/brew-*') }}
-    - name: Install packages that depends on Colima restored from cache
-      if: ${{ steps.homebrew-cache.outputs.cache-hit == 'true' }}
-      run: brew install --only-dependencies colima
-      shell: bash
-    - name: Relink Docker client, Docker Compose, and Colima
-      if: ${{ steps.homebrew-cache.outputs.cache-hit == 'true' }}
+    - name: Install QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Install Colima
       run: |
-        brew unlink docker docker-compose colima lima
-        brew link docker docker-compose colima lima
+        LIMA_VERSION=$(curl -fsSL https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
+        curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
+
+        # download binary
+        COLIMA_VERSION=$(curl -fsSL https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
+        curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA}/colima-$(uname)-$(uname -m)
+
+        # install in $PATH
+        install colima-$(uname)-$(uname -m) /usr/local/bin/colima
       shell: bash
-    - name: Install Docker client, Docker Compose, and Colima.
-      if: ${{ steps.homebrew-cache.outputs.cache-hit != 'true' }}
+    - name: Install Docker client and Docker Compose
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"
-      run: brew install docker docker-compose colima lima
-      shell: bash
-    - name: Manually reinstall QEMU due to bug in GH actions (see https://github.com/actions/runner-images/issues/8104)
-      env:
+        HOMEBREW_NO_INSTALL_UPGRADE: "1"
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
-      run: |
-        brew remove --ignore-dependencies qemu
-        cd /tmp
-        curl -o ./qemu.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/dc0669eca9479e9eeb495397ba3a7480aaa45c2e/Formula/qemu.rb
-        brew install --formula ./qemu.rb
+      run: brew install docker docker-compose
       shell: bash
     - name: Configure Docker Compose plugin
       run: |

--- a/action.yml
+++ b/action.yml
@@ -29,12 +29,14 @@ runs:
         brew update --preinstall
       shell: bash
     - name: Install Colima
+      env:
+        TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        LIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
+        LIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${TOKEN}' https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
         curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
 
         # download binary
-        COLIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
+        COLIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${TOKEN}' https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
         curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA_VERSION}/colima-$(uname)-$(uname -m)
 
         # install in $PATH

--- a/action.yml
+++ b/action.yml
@@ -38,10 +38,9 @@ runs:
         # install in $PATH
         install colima-$(uname)-$(uname -m) /usr/local/bin/colima
       shell: bash
-    - name: Install Docker client and Docker Compose
+    - name: Install QEMU, Docker client, and Docker Compose
       env:
-        HOMEBREW_NO_AUTO_UPDATE: "1"
-      run: brew install docker docker-compose
+      run: brew install docker docker-compose qemu
       shell: bash
     - name: Configure Docker Compose plugin
       run: |
@@ -49,7 +48,7 @@ runs:
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
       shell: bash
     - name: Start Colima
-      run: colima start --vm-type=vz
+      run: colima start
       shell: bash
     - id: docker-client-version
       run: |

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,6 @@ runs:
       run: |
         brew update --preinstall
       shell: bash
-    - name: Install QEMU
-      uses: docker/setup-qemu-action@v2
     - name: Install Colima
       run: |
         LIMA_VERSION=$(curl -fsSL https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Setup Docker on macOS using Colima, Lima-VM, and Homebrew."
 inputs:
   upgrade-qemu:
     description: "Upgrade QEMU to the latest version. Add a lot of time to the job."
-    required: true
+    required: false
     default: "false"
 outputs:
   colima-version:
@@ -54,7 +54,7 @@ runs:
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
       shell: bash
     - name: Upgrade QEMU
-      if: ${{ inputs.upgrade-qemu }} != "false"
+      if: inputs.upgrade-qemu == "true"
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"
         HOMEBREW_NO_INSTALL_UPGRADE: "1"

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
       shell: bash
     - name: Upgrade QEMU
-      if: ${{ inputs.upgrade-qemu == "true" }}
+      if: inputs.upgrade-qemu == "true"
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"
         HOMEBREW_NO_INSTALL_UPGRADE: "1"

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,10 @@
 name: "Setup Docker on macOS"
 description: "Setup Docker on macOS using Colima, Lima-VM, and Homebrew."
+inputs:
+  upgrade-qemu:
+    description: "Upgrade QEMU to the latest version. Add a lot of time to the job."
+    required: false
+    default: "false"
 outputs:
   colima-version:
     value: ${{ steps.colima-version.outputs.version }}
@@ -22,9 +27,6 @@ runs:
     - name: Update Homebrew
       run: |
         brew update --preinstall
-        echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $GITHUB_ENV
-        echo "HOMEBREW_NO_INSTALL_UPGRADE=1" >> $GITHUB_ENV
-        echo "HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1" >> $GITHUB_ENV
       shell: bash
     - name: Install Colima
       run: |
@@ -39,12 +41,23 @@ runs:
         install colima-$(uname)-$(uname -m) /usr/local/bin/colima
       shell: bash
     - name: Install QEMU, Docker client, and Docker Compose
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: "1"
+        HOMEBREW_NO_INSTALL_UPGRADE: "1"
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
       run: brew install docker docker-compose qemu
       shell: bash
     - name: Configure Docker Compose plugin
       run: |
         mkdir -p ~/.docker/cli-plugins
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
+      shell: bash
+    - name: Upgrade QEMU
+      if: ${{ inputs.upgrade-qemu }} == "true"
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: "1"
+        HOMEBREW_NO_INSTALL_UPGRADE: "1"
+      run: brew upgrade qemu
       shell: bash
     - name: Start Colima
       run: colima start

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
       shell: bash
     - name: Start Colima
-      run: colima start
+      run: colima start --vm-type=vz
       shell: bash
     - id: docker-client-version
       run: |

--- a/action.yml
+++ b/action.yml
@@ -29,14 +29,12 @@ runs:
         brew update --preinstall
       shell: bash
     - name: Install Colima
-      env:
-        TOKEN: ${{ github.token }}
       run: |
-        LIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${TOKEN}' https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
+        LIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${{ github.token }}' https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
         curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
 
         # download binary
-        COLIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${TOKEN}' https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
+        COLIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${{ github.token }}' https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
         curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA_VERSION}/colima-$(uname)-$(uname -m)
 
         # install in $PATH

--- a/action.yml
+++ b/action.yml
@@ -29,12 +29,13 @@ runs:
         brew update --preinstall
       shell: bash
     - name: Install Colima
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        LIMA_VERSION=$(curl -fsSL --header 'Authorization: Bearer ${{ github.token }}' https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
+        LIMA_VERSION=$(gh release -R lima-vm/lima view --json tagName -q ".tagName")
         curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
 
-        # download binary
-        COLIMA_VERSION=$(curl -fsSL --header 'Authorization: Bearer ${{ github.token }}' https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
+        COLIMA_VERSION=$(gh release -R abiosoft/colima view --json tagName -q ".tagName")
         curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA_VERSION}/colima-$(uname)-$(uname -m)
 
         # install in $PATH

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Setup Docker on macOS using Colima, Lima-VM, and Homebrew."
 inputs:
   upgrade-qemu:
     description: "Upgrade QEMU to the latest version. Add a lot of time to the job."
-    required: false
+    required: true
     default: "false"
 outputs:
   colima-version:

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
       shell: bash
     - name: Upgrade QEMU
-      if: ${{ inputs.upgrade-qemu }} == "true"
+      if: ${{ inputs.upgrade-qemu }} != "false"
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"
         HOMEBREW_NO_INSTALL_UPGRADE: "1"

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ runs:
     - name: Update Homebrew
       run: |
         brew update --preinstall
+        echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $GITHUB_ENV
+        echo "HOMEBREW_NO_INSTALL_UPGRADE=1" >> $GITHUB_ENV
+        echo "HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1" >> $GITHUB_ENV
       shell: bash
     - name: Install Colima
       run: |
@@ -38,8 +41,6 @@ runs:
     - name: Install Docker client and Docker Compose
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"
-        HOMEBREW_NO_INSTALL_UPGRADE: "1"
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
       run: brew install docker docker-compose
       shell: bash
     - name: Configure Docker Compose plugin

--- a/action.yml
+++ b/action.yml
@@ -46,12 +46,22 @@ runs:
         HOMEBREW_NO_AUTO_UPDATE: "1"
         HOMEBREW_NO_INSTALL_UPGRADE: "1"
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
-      run: brew install docker docker-compose qemu
+      run: |
+        brew install docker docker-compose qemu 2>&1 | tee install.log
       shell: bash
     - name: Configure Docker Compose plugin
       run: |
         mkdir -p ~/.docker/cli-plugins
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
+      shell: bash
+    - name: Check QEMU version
+      if: inputs.upgrade-qemu != 'true'
+      run: |
+        if grep -q "qemu 8.1.0 is already installed" install.log
+        then
+            echo "Detected broken QEMU bottle installed by brew, removing and reinstalling."
+            brew reinstall qemu
+        fi
       shell: bash
     - name: Upgrade QEMU
       if: inputs.upgrade-qemu == 'true'

--- a/action.yml
+++ b/action.yml
@@ -30,11 +30,11 @@ runs:
       shell: bash
     - name: Install Colima
       run: |
-        LIMA_VERSION=$(curl -fsSL https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
+        LIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
         curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
 
         # download binary
-        COLIMA_VERSION=$(curl -fsSL https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
+        COLIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
         curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA_VERSION}/colima-$(uname)-$(uname -m)
 
         # install in $PATH

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,6 @@ runs:
         install colima-$(uname)-$(uname -m) /usr/local/bin/colima
       shell: bash
     - name: Install QEMU, Docker client, and Docker Compose
-      env:
       run: brew install docker docker-compose qemu
       shell: bash
     - name: Configure Docker Compose plugin

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
       shell: bash
     - name: Upgrade QEMU
-      if: inputs.upgrade-qemu == "true"
+      if: inputs.upgrade-qemu == 'true'
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"
         HOMEBREW_NO_INSTALL_UPGRADE: "1"

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
     - name: Install Colima
       env:
-        TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TOKEN: ${{ github.token }}
       run: |
         LIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${TOKEN}' https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
         curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local

--- a/action.yml
+++ b/action.yml
@@ -30,11 +30,11 @@ runs:
       shell: bash
     - name: Install Colima
       run: |
-        LIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${{ github.token }}' https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
+        LIMA_VERSION=$(curl -fsSL --header 'Authorization: Bearer ${{ github.token }}' https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
         curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
 
         # download binary
-        COLIMA_VERSION=$(curl -fsSL --header 'authorization: Bearer ${{ github.token }}' https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
+        COLIMA_VERSION=$(curl -fsSL --header 'Authorization: Bearer ${{ github.token }}' https://api.github.com/repos/abiosoft/colima/releases/latest | jq -r .tag_name)
         curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA_VERSION}/colima-$(uname)-$(uname -m)
 
         # install in $PATH


### PR DESCRIPTION
Given all the recent trouble with Homebrew's conflicts and the QEMU bottle, I'm trying to improve on this regard by doing the following:

- Download Colima and Lima binaries directly from their Github releases. For now, always download the latest version. Later I might add inputs to pick the version. They don't need to be cached anymore.

- By default, use `brew` only to install Docker client and Docker Compose.

- A check for QEMU's brew bottle 8.1.0 has been added. This version is broken and needs to be reinstalled by the action for things to work.

- Added an input that can be used to force a QEMU upgrade.


Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

