### PR TITLE
Allow Colima to be started with `--network-address`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The version of Colima to install. This can be any valid version from [Colima rel
 ## `inputs.colima-network-address` (defaults to `"false"`)
 
 Starts Colima with a reachable network address through passing `--network-address`
-to the `colima start` command.
+to the `colima start` command. Startup will be slower.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ The version of Lima to install. This can be any valid version from [Lima release
 
 The version of Colima to install. This can be any valid version from [Colima releases page](https://github.com/abiosoft/colima/releases)
 
+## `inputs.colima-network-address` (defaults to `"false"`)
+
+Starts Colima with a reachable network address through passing `--network-address`
+to the `colima start` command.
+
 ## Outputs
 
 ## `colima-version`

--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,6 @@ runs:
       env:
         COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}
       run: |
-        echo "::group::Starting Colima"
         ARCH="$(uname -m)"
         if [ $ARCH == "arm64" ]
         then
@@ -123,6 +122,7 @@ runs:
         then
           COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi
+        echo "::group::Starting Colima with args: $COLIMA_ARGS"
         colima start $COLIMA_ARGS
         echo "::endgroup::"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: "latest"
   colima-network-address:
-    description: "Start Colima with a reachable network address (--network-address)."
+    description: "Starts Colima with a reachable network address (`--network-address`). Makes Colima startup slower."
     required: false
     default: "false"
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -112,12 +112,7 @@ runs:
       env:
         COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}
       run: |
-        ARCH="$(uname -m)"
-        if [ $ARCH == "arm64" ]
-        then
-          ARCH="aarch64"
-        fi
-        COLIMA_ARGS="--arch $ARCH"
+        COLIMA_ARGS=""
         if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
           COLIMA_ARGS="$COLIMA_ARGS --network-address"

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ runs:
       run: |
         echo "::group::Starting Colima"
         ARCH="$(uname -m)"
-        if [$ARCH == "arm64"]
+        if [ $ARCH == "arm64" ]
         then
           ARCH="aarch64"
         fi

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: "latest"
   colima-network-address:
-    description: "Start Colima with a reachable network address."
+    description: "Start Colima with a reachable network address (--network-address)."
     required: false
     default: "false"
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ runs:
         COLIMA_ARGS=""
         if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
-        COLIMA_ARGS="$COLIMA_ARGS --network-address"
+          COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi
         colima start $COLIMA_ARGS
         echo "::endgroup::"

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,8 @@ inputs:
     description: "Colima version. Defaults to the latest version."
     required: false
     default: "latest"
-  network:
-    description: start collima with --network-address argument
+  colima-network-address:
+    description: "Start Colima with a reachable network address."
     required: false
     default: "false"
 outputs:
@@ -110,11 +110,11 @@ runs:
       shell: bash
     - name: Start Colima
       env:
-        HOST_NETWORK: ${{ inputs.network }}
+        COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}
       run: |
         echo "::group::Starting Colima"
         COLIMA_ARGS=""
-        if [ $HOST_NETWORK == "true" ]
+        if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
         COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,12 @@ runs:
         COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}
       run: |
         echo "::group::Starting Colima"
-        COLIMA_ARGS=""
+        ARCH="$(uname -m)"
+        if [$ARCH == "arm64"]
+        then
+          ARCH="aarch64"
+        fi
+        COLIMA_ARGS="--arch $ARCH"
         if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
           COLIMA_ARGS="$COLIMA_ARGS --network-address"

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Upgrade QEMU to the latest version. Add a lot of time to the job."
     required: false
     default: "false"
+  network:
+    description: start collima with --network-address argument
+    required: false
+    default: "false"
 outputs:
   colima-version:
     value: ${{ steps.colima-version.outputs.version }}
@@ -71,7 +75,12 @@ runs:
       run: brew upgrade qemu
       shell: bash
     - name: Start Colima
+      if: inputs.network == 'false'
       run: colima start
+      shell: bash
+    - name: Start Colima with network
+      if: inputs.network == 'true'
+      run: colima start --network-address
       shell: bash
     - id: docker-client-version
       run: |


### PR DESCRIPTION
In order to have access to host network, Collima need to be started with --network-address argument. 

I've just added a boolean input to do so. 