### PR TITLE
Allow colima to use more resources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - "main"
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 on:
   push:
-    branches:
-      - "main"
   pull_request:
 
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,9 @@ runs:
       env:
         COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}
       run: |
-        COLIMA_ARGS=""
+        CPU_COUNT=$(sysctl -n hw.ncpu)
+        MEMORY=$(sysctl hw.memsize | awk '{print $2/1024/1024/1024}')
+        COLIMA_ARGS="--cpu $CPU_COUNT --memory $MEMORY"
         if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
           COLIMA_ARGS="$COLIMA_ARGS --network-address"


### PR DESCRIPTION
With this, the VM started by Colima/Lima will have access to all the CPU cores and memory in the runner.