### PR TITLE
Quick failure on M-series (arm64) macOS runners 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
+        os: [macos-12, macos-13]
     name: A job to perform a self-test on this Github Action
     steps:
       # To use this repository's private action,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,11 @@ on:
 
 jobs:
   setup-docker:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-13, macos-14]
     name: A job to perform a self-test on this Github Action
     steps:
       # To use this repository's private action,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
     name: A job to perform a self-test on this Github Action
     steps:
       # To use this repository's private action,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13]
     name: A job to perform a self-test on this Github Action
     steps:
       # To use this repository's private action,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13, macos-14]
+        os: [macos-12, macos-13]
     name: A job to perform a self-test on this Github Action
     steps:
       # To use this repository's private action,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- Fail fast when running on arm64 macOS runners (`macos-14` public runners) ([#28](https://github.com/douglascamata/setup-docker-macos-action/pull/28)).
+  - None of the arm64 processors on Apple computers support nested virtualization as of today (Feb 1st 2024).
+
 ## [v1-alpha.11] - 2024-01-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ I intend this action to be kept as simple as possible:
 - No other OS will be supported.
 - Binaries will be downloaded directly from the source when possible.
 
-# M1, M2, M3 series are unsupported!
+# Currently supported public runner images
+
+- `macos-12`
+- `macos-13`
+
+# ARM64 processors (M1, M2, M3 series) used on `macos-14` images are unsupported!
 
 Yes, exactly what you just read. These processors do not support nested
 virtualization. This means Colima can't start the VM to run Docker.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ I intend this action to be kept as simple as possible:
 - No other OS will be supported.
 - Binaries will be downloaded directly from the source when possible.
 
+# M1, M2, M3 series are unsupported!
+
+Yes, exactly what you just read. These processors do not support nested
+virtualization. This means Colima can't start the VM to run Docker.
+
+I'm sorry, but there's nothing I can do about it. All we can do is wait until
+an M-series processor supports it and Github adopts such processors for action
+runners.
+
 ## Features
 
 - Safety check to ensure the action is running in macOS.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ I intend this action to be kept as simple as possible:
 Yes, exactly what you just read. These processors do not support nested
 virtualization. This means Colima can't start the VM to run Docker.
 
-I'm sorry, but there's nothing I can do about it. All we can do is wait until
-an M-series processor supports it and Github adopts such processors for action
-runners.
+For the M1 processor there is no hope. It lacks the hardware support for this.
+
+The M2 and M3 processors have such hardware support, but no software support
+from Apple's Hypervisor framework (so no hopes for QEMU) or Virtualization
+framework (alternative to QEMU).
+
+I'm sorry, but there's nothing I can do about it. All we can do is wait. If I
+miss the announcement of nested virtualization support, please open an issue.
 
 ## Features
 

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,7 @@ runs:
       run: |
         arch_name=$(uname -m)
         if [ "$arch_name" = "arm64" ]
+        then
             echo "Detected M-series processor runner without nested virtualization support, exiting."
             exit 1
         else

--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,16 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Safety check
+    - name: OS safety check
       if: runner.os != 'macOS'
       run: |
         echo "Not a macOS runner, exiting."
+        exit 1
+      shell: bash
+    - name: M-series safety check
+      if: matrix.os == 'macos-14'
+      run: |
+        echo "Detected M-series processor runner without nested virtualization support, exiting."
         exit 1
       shell: bash
     - name: Update Homebrew

--- a/action.yml
+++ b/action.yml
@@ -36,11 +36,15 @@ runs:
         echo "Not a macOS runner, exiting."
         exit 1
       shell: bash
-    - name: M-series safety check
-      if: matrix.os == 'macos-14'
+    - name: ARM64 safety check
       run: |
-        echo "Detected M-series processor runner without nested virtualization support, exiting."
-        exit 1
+        arch_name=$(uname -m)
+        if [ "$arch_name" = "arm64" ]
+            echo "Detected M-series processor runner without nested virtualization support, exiting."
+            exit 1
+        else
+            echo "Running on supported architecture: ${arch_name}"
+        fi
       shell: bash
     - name: Update Homebrew
       run: |


### PR DESCRIPTION
After a long investigation triggered by #26, I discovered that all the M-series processors available today can't be supported by this action. They lack support for nested virtualization (hardware level for M1, software level for M2 and M3).

Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>