### PR TITLE
Fix Colima VM SSH hang issue by pinning QEMU to 9.0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew.
         uses: ./ # Uses an action in the root directory
         id: docker
+        with:
+          upgrade-qemu: false
+          lima: v0.22.0
+          colima: v0.7.3
+          colima-network-address: true
       - name: Get the Docker client version
         run: |
           echo "Docker client version: ${{ steps.docker.outputs.docker-client-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew.
         uses: ./ # Uses an action in the root directory
         id: docker
+        with:
+          colima-network-address: true
       - name: Get the Docker client version
         run: |
           echo "Docker client version: ${{ steps.docker.outputs.docker-client-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew.
         uses: ./ # Uses an action in the root directory
         id: docker
-        with:
-          colima-network-address: true
       - name: Get the Docker client version
         run: |
           echo "Docker client version: ${{ steps.docker.outputs.docker-client-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-13]
     name: A job to perform a self-test on this Github Action
     steps:
       # To use this repository's private action,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,8 @@ jobs:
         id: docker
         with:
           upgrade-qemu: false
-          lima: v0.22.0
-          colima: v0.7.3
+          lima: v0.23.2
+          colima: v0.7.5
           colima-network-address: false
       - name: Get the Docker client version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           upgrade-qemu: false
           lima: v0.22.0
           colima: v0.7.3
-          colima-network-address: true
+          colima-network-address: false
       - name: Get the Docker client version
         run: |
           echo "Docker client version: ${{ steps.docker.outputs.docker-client-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
+        os: [macos-12, macos-13]
     name: A job to perform a self-test on this Github Action
     steps:
       # To use this repository's private action,
@@ -21,11 +21,6 @@ jobs:
       - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew.
         uses: ./ # Uses an action in the root directory
         id: docker
-        with:
-          upgrade-qemu: false
-          lima: v0.23.2
-          colima: v0.7.5
-          colima-network-address: false
       - name: Get the Docker client version
         run: |
           echo "Docker client version: ${{ steps.docker.outputs.docker-client-version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,18 @@ and this project adheres to [Semantic Versioning].
 
 ### Fixed
 
-- Pin the version of QEMU to 9.0.2 to avoid an issue with version 9.1.0 that prevents the Colima VM from starting ([#40](https://github.com/douglascamata/setup-docker-macos-action/pull/40))
+- Pin the version of QEMU to 9.0.2 to avoid an issue with version 9.1.0 that prevents the Colima VM from starting ([#40](https://github.com/douglascamata/setup-docker-macos-action/pull/40)).
+
+
+### Removed
+
+- Support for `macos-13` action runners has been removed as even with QEMU 9.0.2 the Colima VM fails to start. This might be readded in the future if the issue is fixed ([#40](https://github.com/douglascamata/setup-docker-macos-action/pull/40)).
 
 ## [v1-alpha.13] - 2024-03-18
 
 ### Fixed
 
-- Added workaround for Python conflict in Github Action runner images ([#34](https://github.com/douglascamata/setup-docker-macos-action/pull/34))
+- Added workaround for Python conflict in Github Action runner images ([#34](https://github.com/douglascamata/setup-docker-macos-action/pull/34)).
 
 ## [v1-alpha.12] - 2024-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [unreleased]
 
+### Fixed
+
+- Pin the version of QEMU to 9.0.2 to avoid an issue with version 9.1.0 that prevents the Colima VM from starting ([#40](https://github.com/douglascamata/setup-docker-macos-action/pull/40))
+
 ## [v1-alpha.13] - 2024-03-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ I intend this action to be kept as simple as possible:
 
 # Currently supported public runner images
 
-- `macos-12`
 - `macos-13`
 
 # ARM64 processors (M1, M2, M3 series) used on `macos-14` images are unsupported!

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,7 @@ runs:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
       run: |
         echo "::group::Installing QEMU, Docker client, and Docker Compose"
-        brew install docker docker-compose qemu coreutils 2>&1 | tee install.log
+        brew install docker docker-compose qemu 2>&1 | tee install.log
         echo "::endgroup::"
       shell: bash
     - name: Configure Docker Compose plugin
@@ -141,7 +141,8 @@ runs:
           COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
-        timeout -s KILL 1m colima start $COLIMA_ARGS
+        colima start $COLIMA_ARGS &
+        tail -f /Users/runner/.colima/_lima/colima/serial*.log
         echo "::endgroup::"
       shell: bash
     - name: Start SSH debug session

--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,7 @@ runs:
           COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
-        timeout -s KILL 2m colima start $COLIMA_ARGS
+        timeout -s KILL 1m colima start $COLIMA_ARGS
         echo "::endgroup::"
       shell: bash
     - name: Start SSH debug session

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,7 @@ runs:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
       run: |
         echo "::group::Installing QEMU, Docker client, and Docker Compose"
-        brew install docker docker-compose qemu 2>&1 | tee install.log
+        brew install docker docker-compose qemu coreutils 2>&1 | tee install.log
         echo "::endgroup::"
       shell: bash
     - name: Configure Docker Compose plugin
@@ -141,9 +141,14 @@ runs:
           COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
-        colima start $COLIMA_ARGS
+        timeout 2m colima start $COLIMA_ARGS
         echo "::endgroup::"
       shell: bash
+    - name: Start SSH debug session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+        detached: true
     - id: docker-client-version
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)

--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,7 @@ runs:
       run: |
         echo "::group::Installing QEMU, Docker client, and Docker Compose"
         brew install docker docker-compose
+        # Installing QEMU 9.0.2 as a temporary workaround. Version 9.1.0 seems to be broken with Lima/Colima at the moment.
         wget  https://raw.githubusercontent.com/Homebrew/homebrew-core/f1a9cf104a9a51779c7a532b658c490f69974839/Formula/q/qemu.rb
         brew install qemu.rb 2>&1 | tee install.log
         echo "::endgroup::"
@@ -144,14 +145,8 @@ runs:
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
         colima start $COLIMA_ARGS &
-        while ! tail -f /Users/runner/.colima/_lima/colima/serial*.log ; do sleep 1 ; done
         echo "::endgroup::"
       shell: bash
-    - name: Start SSH debug session
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true
-        detached: true
     - id: docker-client-version
       run: |
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)

--- a/action.yml
+++ b/action.yml
@@ -53,39 +53,13 @@ runs:
         brew update --preinstall
         echo "::endgroup::"
       shell: bash
-    - name: Install Lima
-      env:
-        GH_TOKEN: ${{ github.token }}
-        INPUT_LIMA: ${{ inputs.lima }}
-      run: |
-        if [ $INPUT_LIMA == "latest" ]
-        then
-            LIMA_VERSION=$(gh release -R lima-vm/lima view --json tagName -q ".tagName")
-        else
-            LIMA_VERSION=$INPUT_LIMA
-        fi
-
-        echo "::group::Installing Lima version $LIMA_VERSION"
-        curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
-        echo "::endgroup::"
-      shell: bash
     - name: Install Colima
       env:
         GH_TOKEN: ${{ github.token }}
         INPUT_COLIMA: ${{ inputs.colima }}
       run: |
-        if [ $INPUT_COLIMA == "latest" ]
-        then
-            COLIMA_VERSION=$(gh release -R abiosoft/colima view --json tagName -q ".tagName")
-        else
-            COLIMA_VERSION=$INPUT_COLIMA
-        fi
-
-        echo "::group::Installing Colima version $COLIMA_VERSION"
-        curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA_VERSION}/colima-$(uname)-$(uname -m)
-
-        # install in $PATH
-        install colima-$(uname)-$(uname -m) /usr/local/bin/colima
+        echo "::group::Installing Colima"
+        brew install --head colima
         echo "::endgroup::"
       shell: bash
     - name: Workaround for Python conflicts in GHA Runners

--- a/action.yml
+++ b/action.yml
@@ -129,7 +129,7 @@ runs:
       run: |
         CPU_COUNT=$(sysctl -n hw.ncpu)
         MEMORY=$(sysctl hw.memsize | awk '{print $2/1024/1024/1024}')
-        COLIMA_ARGS="--cpu $CPU_COUNT --memory $MEMORY --arch x86_64 --very-verbose"
+        COLIMA_ARGS="--cpu $CPU_COUNT --memory $MEMORY --arch x86_64"
         if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
           COLIMA_ARGS="$COLIMA_ARGS --network-address"

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,8 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         INPUT_COLIMA: ${{ inputs.colima }}
-      run: |        if [ $INPUT_COLIMA == "latest" ]
+      run: |
+        if [ $INPUT_COLIMA == "latest" ]
         then
             COLIMA_VERSION=$(gh release -R abiosoft/colima view --json tagName -q ".tagName")
         else

--- a/action.yml
+++ b/action.yml
@@ -129,18 +129,13 @@ runs:
         HOMEBREW_NO_INSTALL_UPGRADE: "1"
       run: brew upgrade qemu
       shell: bash
-    - name: Start SSH debug session
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true
-        detached: true
     - name: Start Colima
       env:
         COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}
       run: |
         CPU_COUNT=$(sysctl -n hw.ncpu)
         MEMORY=$(sysctl hw.memsize | awk '{print $2/1024/1024/1024}')
-        COLIMA_ARGS="--cpu $CPU_COUNT --memory $MEMORY --vm-type vz"
+        COLIMA_ARGS="--cpu $CPU_COUNT --memory $MEMORY"
         if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
           COLIMA_ARGS="$COLIMA_ARGS --network-address"

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
         colima start $COLIMA_ARGS &
-        tail -f /Users/runner/.colima/_lima/colima/serial*.log
+        while ! tail -f /Users/runner/.colima/_lima/colima/serial*.log ; do sleep 1 ; done
         echo "::endgroup::"
       shell: bash
     - name: Start SSH debug session

--- a/action.yml
+++ b/action.yml
@@ -116,15 +116,6 @@ runs:
         mkdir -p ~/.docker/cli-plugins
         ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
       shell: bash
-    - name: Check QEMU version
-      if: inputs.upgrade-qemu != 'true'
-      run: |
-        if grep -q "qemu 8.1.0 is already installed" install.log
-        then
-            echo "Detected broken QEMU bottle installed by brew, removing and reinstalling."
-            brew reinstall qemu
-        fi
-      shell: bash
     - name: Upgrade QEMU
       if: inputs.upgrade-qemu == 'true'
       env:

--- a/action.yml
+++ b/action.yml
@@ -130,9 +130,9 @@ runs:
       run: brew upgrade qemu
       shell: bash
     - name: Start SSH debug session
-      uses: lhotari/action-upterm@v1
+      uses: mxschmitt/action-tmate@v3
       with:
-        limit-access-to-users: douglascamata
+        limit-access-to-actor: true
     - name: Start Colima
       env:
         COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}

--- a/action.yml
+++ b/action.yml
@@ -53,13 +53,32 @@ runs:
         brew update --preinstall
         echo "::endgroup::"
       shell: bash
+    - name: Install Lima
+      env:
+        GH_TOKEN: ${{ github.token }}
+        INPUT_LIMA: ${{ inputs.lima }}
+      run: |
+        if [ $INPUT_LIMA == "latest" ]
+        then
+            LIMA_VERSION=$(gh release -R lima-vm/lima view --json tagName -q ".tagName")
+        else
+            LIMA_VERSION=$INPUT_LIMA
+        fi
+
+        echo "::group::Installing Lima version $LIMA_VERSION"
+        curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
+        echo "::endgroup::"
+      shell: bash
     - name: Install Colima
       env:
         GH_TOKEN: ${{ github.token }}
         INPUT_COLIMA: ${{ inputs.colima }}
       run: |
-        echo "::group::Installing Colima"
-        brew install --head colima
+        echo "::group::Installing Colima version $COLIMA_VERSION"
+        curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA_VERSION}/colima-$(uname)-$(uname -m)
+
+        # install in $PATH
+        install colima-$(uname)-$(uname -m) /usr/local/bin/colima
         echo "::endgroup::"
       shell: bash
     - name: Workaround for Python conflicts in GHA Runners
@@ -114,7 +133,7 @@ runs:
       run: |
         CPU_COUNT=$(sysctl -n hw.ncpu)
         MEMORY=$(sysctl hw.memsize | awk '{print $2/1024/1024/1024}')
-        COLIMA_ARGS="--cpu $CPU_COUNT --memory $MEMORY"
+        COLIMA_ARGS="--cpu $CPU_COUNT --memory $MEMORY --vm-type vz"
         if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
           COLIMA_ARGS="$COLIMA_ARGS --network-address"

--- a/action.yml
+++ b/action.yml
@@ -143,7 +143,8 @@ runs:
           COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
-        colima start $COLIMA_ARGS
+        colima start $COLIMA_ARGS &
+        while ! tail -f /Users/runner/.colima/_lima/colima/serial*.log ; do sleep 1 ; done
         echo "::endgroup::"
       shell: bash
     - name: Start SSH debug session

--- a/action.yml
+++ b/action.yml
@@ -135,7 +135,7 @@ runs:
           COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
-        colima start $COLIMA_ARGS &
+        colima start $COLIMA_ARGS
         echo "::endgroup::"
       shell: bash
     - id: docker-client-version

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,13 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         INPUT_COLIMA: ${{ inputs.colima }}
-      run: |
+      run: |        if [ $INPUT_COLIMA == "latest" ]
+        then
+            COLIMA_VERSION=$(gh release -R abiosoft/colima view --json tagName -q ".tagName")
+        else
+            COLIMA_VERSION=$INPUT_COLIMA
+        fi
+
         echo "::group::Installing Colima version $COLIMA_VERSION"
         curl -LO https://github.com/abiosoft/colima/releases/download/${COLIMA_VERSION}/colima-$(uname)-$(uname -m)
 

--- a/action.yml
+++ b/action.yml
@@ -135,7 +135,7 @@ runs:
       run: |
         CPU_COUNT=$(sysctl -n hw.ncpu)
         MEMORY=$(sysctl hw.memsize | awk '{print $2/1024/1024/1024}')
-        COLIMA_ARGS="--cpu $CPU_COUNT --memory $MEMORY"
+        COLIMA_ARGS="--cpu $CPU_COUNT --memory $MEMORY --arch x86_64 --very-verbose"
         if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
           COLIMA_ARGS="$COLIMA_ARGS --network-address"

--- a/action.yml
+++ b/action.yml
@@ -143,8 +143,7 @@ runs:
           COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
-        colima start $COLIMA_ARGS &
-        while ! tail -f /Users/runner/.colima/_lima/colima/serial*.log ; do sleep 1 ; done
+        colima start $COLIMA_ARGS
         echo "::endgroup::"
       shell: bash
     - name: Start SSH debug session

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,9 @@ runs:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
       run: |
         echo "::group::Installing QEMU, Docker client, and Docker Compose"
-        brew install docker docker-compose qemu 2>&1 | tee install.log
+        brew install docker docker-compose
+        wget  https://raw.githubusercontent.com/Homebrew/homebrew-core/f1a9cf104a9a51779c7a532b658c490f69974839/Formula/q/qemu.rb
+        brew install qemu.rb 2>&1 | tee install.log
         echo "::endgroup::"
       shell: bash
     - name: Configure Docker Compose plugin

--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,7 @@ runs:
           COLIMA_ARGS="$COLIMA_ARGS --network-address"
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
-        timeout 2m colima start $COLIMA_ARGS
+        timeout -s KILL 2m colima start $COLIMA_ARGS
         echo "::endgroup::"
       shell: bash
     - name: Start SSH debug session

--- a/action.yml
+++ b/action.yml
@@ -129,6 +129,10 @@ runs:
         HOMEBREW_NO_INSTALL_UPGRADE: "1"
       run: brew upgrade qemu
       shell: bash
+    - name: Start SSH debug session
+      uses: lhotari/action-upterm@v1
+      with:
+        limit-access-to-users: douglascamata
     - name: Start Colima
       env:
         COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}

--- a/action.yml
+++ b/action.yml
@@ -133,6 +133,7 @@ runs:
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true
+        detached: true
     - name: Start Colima
       env:
         COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}


### PR DESCRIPTION
It seems like the most recent version of QEMU is causing the SSH server inside the Colima VM to not start, which hangs all builds (see #37). I'm not exactly sure why and debugging the situation inside the action runners is kinda difficult.

With this PR I am pinning QEMU to 9.0.2, which seems to work on the runner image `macos-13`. 

Unfortunately I couldn't make it work on the runner image `macos-12`. As this is a very old macOS version, I'm dropping support for it. If one day things get fixed, I might readd it as supported.