### PR TITLE
Enabled custom Colima options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning].
 
 - Support for native virtualization provided by macOS Virtualization framework. In detail, now Lima VMs are configured to use `vz` as the VM type and `virtiofs` for mounts. This change leads to significant stability and performance improvements ([#42](https://github.com/douglascamata/setup-docker-macos-action/pull/42)).
 
+- Support for passing custom parameters to the `colima start` command through the `colima-additional-options` input field. Please use this field carefully, as a wrong, obsolete, or unsupported set of options may break Colima startup ([#43](https://github.com/douglascamata/setup-docker-macos-action/pull/43)).
+
 ### Removed
 
 - Support for QEMU virtualization, which has historically been fragile and hard to maintain. The related `upgrade-qemu` config flag has also been removed ([#42](https://github.com/douglascamata/setup-docker-macos-action/pull/42)).

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ The version of Colima to install. This can be any valid version from [Colima rel
 Starts Colima with a reachable network address through passing `--network-address`
 to the `colima start` command. Startup will be slower.
 
+## `inputs.colima-additional-options`
+
+Adds custom parameters to the `colima start` command. Please use this field carefully,
+as a wrong, obsolete, or unsupported set of parameters may break Colima startup.
+
 ## Outputs
 
 ## `colima-version`

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: "Starts Colima with a reachable network address (`--network-address`). Makes Colima startup slower."
     required: false
     default: "false"
+  colima-additional-options:
+    description: "Starts Colima with additional options. May break Colima startup."
+    required: false
 outputs:
   colima-version:
     value: ${{ steps.colima-version.outputs.version }}
@@ -111,6 +114,7 @@ runs:
       shell: bash
     - name: Start Colima
       env:
+        COLIMA_ADDITIONAL_OPTIONS: ${{ inputs.colima-additional-options }}
         COLIMA_NETWORK_ADDRESS: ${{ inputs.colima-network-address }}
       run: |
         CPU_COUNT=$(sysctl -n hw.ncpu)
@@ -119,6 +123,10 @@ runs:
         if [ $COLIMA_NETWORK_ADDRESS == "true" ]
         then
           COLIMA_ARGS="$COLIMA_ARGS --network-address"
+        fi
+        if [ -n "$COLIMA_ADDITIONAL_OPTIONS" ]
+        then
+          COLIMA_ARGS="$COLIMA_ARGS $COLIMA_ADDITIONAL_OPTIONS"
         fi
         echo "::group::Starting Colima with args: $COLIMA_ARGS"
         colima start $COLIMA_ARGS


### PR DESCRIPTION
This commit allows users to specify additional options when starting the Colima VM. This behaviour is enabled by the new `colima-additional-options` input of the GitHub Action.