### PR TITLE
Fix `brew update` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Run `brew update` without `--preinstall`, as it was removed from Homebrew since a while and 4.4.16 started rejecting it. ([#45](https://github.com/douglascamata/setup-docker-macos-action/pull/45))
+
 ## [v1-alpha.15] - 2024-11-27
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Update Homebrew
       run: |
         echo "::group::Updating Homebrew"
-        brew update --preinstall
+        brew update
         echo "::endgroup::"
       shell: bash
     - name: Install Lima


### PR DESCRIPTION
The `--preinstall` long option has bene removed since a while and starting on version `4.4.16` Homebrew is rejecting any unknown long option.