### PR TITLE
Remove Python conflicts workaround

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,16 +87,6 @@ runs:
         install colima-$(uname)-$(uname -m) /usr/local/bin/colima
         echo "::endgroup::"
       shell: bash
-    - name: Workaround for Python conflicts in GHA Runners
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: "1"
-        HOMEBREW_NO_INSTALL_UPGRADE: "1"
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
-      run: |
-        brew unlink python@3 || true
-        brew uninstall --ignore-dependencies python@3 || true
-        brew install --overwrite --force python@3
-      shell: bash
     - name: Install Docker client, and Docker Compose
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"


### PR DESCRIPTION
The removed code had been introduced to resolve a linking problem with the QEMU dependency (#31). However, this action no longer installs QEMU as a dependency. Therefore, this code can be safely removed to speedup the whole process and reduce the error surface.