### PR TITLE
Fix setup for Lima v2.0 and above

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,12 @@ runs:
         fi
 
         echo "::group::Installing Lima version $LIMA_VERSION"
+        
+        if [[ $LIMA_VERSION == v2.* ]]; then
+            sudo mkdir /usr/local/libexec
+            sudo chown $UID:$GID /usr/local/libexec
+        fi
+
         curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | tar Cxzvm /usr/local
         echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
Before this commit, Lima v2.0 fails to be downloaded properly due to the lack of the `libexec` folder and the lack of permissions to create it. This commit fixes #53 by forcing the creation of the `libexec` folder as a privileged user before starting the download, solving the issue.